### PR TITLE
SIANXSVC-1189: Fix timeouts causing clients to never receive an answer in pipelines

### DIFF
--- a/client.go
+++ b/client.go
@@ -245,7 +245,6 @@ func (this *Client) FlushRedisAndRespond() (err error) {
 
 	if err = protocol.CopyServerResponses(redisConn.Reader, this.Writer, numCommands); err != nil {
 		log.Error("Error when copying redis responses to client: %s. Disconnecting the connection.", err)
-		this.ReadChannel <- readItem{nil, err}
 		return
 	}
 

--- a/server.go
+++ b/server.go
@@ -388,9 +388,9 @@ func (this *RedisMultiplexer) HandleError(client *Client, err error) {
 		client.Active = false
 		return
 	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		// We had a read timeout. Let the client know that the connection is down
+		// We had a read timeout. Disconnect the client to ensure a known state.
 		graphite.Increment("nettimeout")
-		client.FlushError(ERR_TIMEOUT)
+		client.Active = false
 		return
 	} else {
 		// This is something we've never seen before! Panic panic panic


### PR DESCRIPTION
Due to a bug clients were stalled waiting for a response which would never come due to incorrect error handling in Rmux. This only affected pipelines and network timeouts.